### PR TITLE
From Manifest package declaration to build.gradle namespace

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -44,6 +44,7 @@ android {
             excludes += '/META-INF/{AL2.0,LGPL2.1}'
         }
     }
+    namespace 'com.flightsearch'
 }
 
 dependencies {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.flightsearch">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <application
         android:name=".FlightSearchApplication"


### PR DESCRIPTION
Placing the namespace declaration in the build.gradle file allows for greater flexibility in managing the project's build configurations. It enables you to configure different flavors, build types, product flavors, and variants of your application, each with its own unique package name. This can be useful when you need to create different versions of your app (e.g., free and paid versions, different flavors for different environments) or when integrating with build automation systems like Gradle.